### PR TITLE
feat: Add `decimals` check (SC-5068)

### DIFF
--- a/contracts/Migrator.sol
+++ b/contracts/Migrator.sol
@@ -3,12 +3,16 @@ pragma solidity 0.8.7;
 
 import { ERC20Helper } from "../modules/erc20-helper/src/ERC20Helper.sol";
 
+import { IERC20Like } from "./interfaces/Interfaces.sol";
+
 contract Migrator {
 
     address public immutable oldToken;
     address public immutable newToken;
 
     constructor(address oldToken_, address newToken_) {
+        require(IERC20Like(newToken_).decimals() == IERC20Like(oldToken_).decimals(), "M:C:DECIMAL_MISMATCH");
+
         oldToken = oldToken_;
         newToken = newToken_;
     }

--- a/contracts/interfaces/Interfaces.sol
+++ b/contracts/interfaces/Interfaces.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity 0.8.7;
+
+interface IERC20Like {
+
+    function decimals() external view returns (uint8 decimals_);
+
+}

--- a/contracts/test/Migrator.t.sol
+++ b/contracts/test/Migrator.t.sol
@@ -16,6 +16,28 @@ contract SomeAccount {
 
 }
 
+contract MigratorConstructorTest is TestUtils {
+
+    function test_constructor_mismatch_decimals() external {
+        MockERC20 oldToken = new MockERC20("Old Token", "OT", 18);
+        MockERC20 newToken = new MockERC20("New Token", "NT", 17);
+
+        vm.expectRevert("M:C:DECIMAL_MISMATCH");
+        new Migrator(address(oldToken), address(newToken));
+    }
+
+    function test_constructor() external {
+        MockERC20 oldToken = new MockERC20("Old Token", "OT", 18);
+        MockERC20 newToken = new MockERC20("New Token", "NT", 18);
+
+        Migrator migrator = new Migrator(address(oldToken), address(newToken));
+
+        assertEq(migrator.oldToken(), address(oldToken));
+        assertEq(migrator.newToken(), address(newToken));
+    }
+
+}
+
 contract MigratorTest is TestUtils {
 
     uint256 public constant OLD_SUPPLY = 10_000_000 ether;


### PR DESCRIPTION
Adds a require to the constructor of the constructor to ensure that the newAssets decimals match the oldAsset.